### PR TITLE
Fix invalid parameter on powermetrics

### DIFF
--- a/asitop/utils.py
+++ b/asitop/utils.py
@@ -71,7 +71,7 @@ def convert_to_GB(value):
 
 def run_powermetrics_process(timecode, nice=10, interval=1000):
     ver, *_ = platform.mac_ver()
-    major_ver = ver.split(".")[0]
+    major_ver = int(ver.split(".")[0])
     output_file_flag = "-u"
 
     if major_ver >= 12:

--- a/asitop/utils.py
+++ b/asitop/utils.py
@@ -72,7 +72,7 @@ def run_powermetrics_process(timecode, nice=10, interval=1000):
     command = " ".join([
         "sudo nice -n",
         str(nice),
-        "powermetrics --samplers cpu_power,gpu_power,thermal,bandwidth -o /tmp/asitop_powermetrics"+timecode,
+        "powermetrics --samplers cpu_power,gpu_power,thermal,bandwidth -u /tmp/asitop_powermetrics"+timecode,
         "-f plist",
         "-i",
         str(interval)

--- a/asitop/utils.py
+++ b/asitop/utils.py
@@ -1,3 +1,4 @@
+import platform
 import os
 import time
 import subprocess
@@ -69,10 +70,20 @@ def convert_to_GB(value):
 
 
 def run_powermetrics_process(timecode, nice=10, interval=1000):
+    ver, *_ = platform.mac_ver()
+    major_ver = ver.split(".")[0]
+    output_file_flag = "-u"
+
+    if major_ver >= 12:
+        output_file_flag = "-o"
+
     command = " ".join([
         "sudo nice -n",
         str(nice),
-        "powermetrics --samplers cpu_power,gpu_power,thermal,bandwidth -u /tmp/asitop_powermetrics"+timecode,
+        "powermetrics",
+        "--samplers cpu_power,gpu_power,thermal,bandwidth", 
+        output_file_flag,
+        "/tmp/asitop_powermetrics"+timecode,
         "-f plist",
         "-i",
         str(interval)


### PR DESCRIPTION
I have an error running asitop, it tells that powermetrics got invalid parameter. I looked closer and find out that -u parameter should be passed instead of -o
```
> powermetrics --help | grep output
    -u | --output-file <file>    output to file [default: stdout]
```

I am running this on MacBook Air M1 and maybe you have different parameters so let me know if that's a valid fix.