### PR TITLE
Check return code of powermetrics and throw excpetion accordingly

### DIFF
--- a/asitop/utils.py
+++ b/asitop/utils.py
@@ -61,6 +61,9 @@ def run_powermetrics_process(timecode, nice=10, interval=1000):
             str(interval)
         ])
         process = subprocess.Popen(command.split(" "), stdin=PIPE, stdout=PIPE)
+        rc = process.returncode
+        if rc != 0:
+            raise Exception("powermetrics output file flag")
     except Exception as e:
         print("Error starting powermetrics process", e)
         print("Switch output_file_flag to `-u`")


### PR DESCRIPTION
Check the return code of powermetrics process and throw exception if return code is non-zero.

This happens "-u" vs "-o" arguments change and current exception handler does not handle return code.

This patch fixes reported issue: powermetrics: unrecognized order: /tmp/asitop_powermetrics1638952131 #17 
and also allows asitop to run on BigSur.