### PR TITLE
add --max_count arguement to prevent large memory usage after a long time

### DIFF
--- a/asitop/asitop.py
+++ b/asitop/asitop.py
@@ -14,6 +14,8 @@ parser.add_argument('--avg', type=int, default=30,
                     help='Interval for averaged values (seconds)')
 parser.add_argument('--show_cores', type=bool, default=False,
                     help='Choose show cores mode')
+parser.add_argument('--max_count', type=int, default=0,
+                    help='Max show count to restart powermetrics')
 args = parser.parse_args()
 
 
@@ -168,13 +170,14 @@ def main():
     count=0
     try:
         while True:
-            if (count >= 1800):
-                count = 0
-                powermetrics_process.terminate()
-                timecode = str(int(time.time()))
-                powermetrics_process = run_powermetrics_process(
-                    timecode, interval=args.interval * 1000)
-            count += 1
+            if args.max_count > 0:
+                if count >= args.max_count:
+                    count = 0
+                    powermetrics_process.terminate()
+                    timecode = str(int(time.time()))
+                    powermetrics_process = run_powermetrics_process(
+                        timecode, interval=args.interval * 1000)
+                count += 1
             ready = parse_powermetrics(timecode=timecode)
             if ready:
                 cpu_metrics_dict, gpu_metrics_dict, thermal_pressure, bandwidth_metrics, timestamp = ready

--- a/asitop/asitop.py
+++ b/asitop/asitop.py
@@ -165,8 +165,16 @@ def main():
 
     clear_console()
 
+    count=0
     try:
         while True:
+            if (count >= 1800):
+                count = 0
+                powermetrics_process.terminate()
+                timecode = str(int(time.time()))
+                powermetrics_process = run_powermetrics_process(
+                    timecode, interval=args.interval * 1000)
+            count += 1
             ready = parse_powermetrics(timecode=timecode)
             if ready:
                 cpu_metrics_dict, gpu_metrics_dict, thermal_pressure, bandwidth_metrics, timestamp = ready


### PR DESCRIPTION
As #6 mentioned, run asitop over a long time, a python progress would occupy large amount of memory. This pr add an option of '--max_count' to specify how many refresh times after to restart the powermetrics process.