### PR TITLE
Update TDP and bandwidth information for Apple M2

### DIFF
--- a/asitop/utils.py
+++ b/asitop/utils.py
@@ -158,6 +158,9 @@ def get_soc_info():
     elif soc_info["name"] == "Apple M1 Ultra":
         soc_info["cpu_max_power"] = 60
         soc_info["gpu_max_power"] = 120
+    elif soc_info["name"] == "Apple M2":
+        soc_info["cpu_max_power"] = 25
+        soc_info["gpu_max_power"] = 15
     else:
         soc_info["cpu_max_power"] = 20
         soc_info["gpu_max_power"] = 20

--- a/asitop/utils.py
+++ b/asitop/utils.py
@@ -174,6 +174,9 @@ def get_soc_info():
     elif soc_info["name"] == "Apple M1 Ultra":
         soc_info["cpu_max_bw"] = 500
         soc_info["gpu_max_bw"] = 800
+    elif soc_info["name"] == "Apple M2":
+        soc_info["cpu_max_bw"] = 100
+        soc_info["gpu_max_bw"] = 100
     else:
         soc_info["cpu_max_bw"] = 70
         soc_info["gpu_max_bw"] = 70


### PR DESCRIPTION
The CPU power limit is set to 25 W. [source](https://youtu.be/nVIknUcCjiQ?t=314)
(P-cores can consume 25 watts for the first few seconds)

The GPU power limit is set to 15 W. [source](https://youtu.be/nVIknUcCjiQ?t=568)

The memory bandwidth should be 100 GB/s. [source](https://www.apple.com/newsroom/2022/06/apple-unveils-m2-with-breakthrough-performance-and-capabilities/)


I personally own a MacBook Air equipped with M2,
 and I am happy to validate the data above
 if there are proper/recommended ways to estimate the numbers :).