### PR TITLE
fix: restore compatibility with macOS 12 Monterey

### DIFF
--- a/asitop/parsers.py
+++ b/asitop/parsers.py
@@ -127,7 +127,12 @@ def parse_cpu_metrics(powermetrics_parse):
     #cpu_metric_dict["dram_W"] = cpu_metrics["dram_energy"]/1000
     cpu_metric_dict["cpu_W"] = cpu_metrics["cpu_energy"]/1000
     cpu_metric_dict["gpu_W"] = cpu_metrics["gpu_energy"]/1000
-    cpu_metric_dict["package_W"] = cpu_metrics["combined_power"]/1000
+    if "combined_power" in cpu_metrics.keys():
+        # macOS 13 Ventura
+        cpu_metric_dict["package_W"] = cpu_metrics["combined_power"]/1000
+    else:
+        # macOS 12 Monterey
+        cpu_metric_dict["package_W"] = cpu_metrics["package_energy"]/1000
     return cpu_metric_dict
 
 


### PR DESCRIPTION
Fixes #51 where the power usage key was renamed from `package_energy` to `combined_power` in macOS Ventura, resulting in the following error when attempting to run asitop under Monterey:

```
[3/3] Waiting for first reading...

Traceback (most recent call last):
  File "/opt/homebrew/lib/python3.11/site-packages/asitop/utils.py", line 18, in parse_powermetrics
    cpu_metrics_dict = parse_cpu_metrics(powermetrics_parse)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/asitop/parsers.py", line 133, in parse_cpu_metrics
    cpu_metric_dict["package_W"] = cpu_metrics["combined_power"]/1000
                                   ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
KeyError: 'combined_power'
```