### PR TITLE
use average of (1 - CPU idle ratio) across CPUs in the cluster for P- and E-Cluster usage

### DIFF
--- a/asitop/parsers.py
+++ b/asitop/parsers.py
@@ -85,12 +85,13 @@ def parse_cpu_metrics(powermetrics_parse):
     for cluster in cpu_clusters:
         name = cluster["name"]
         cpu_metric_dict[name+"_freq_Mhz"] = int(cluster["freq_hz"]/(1e6))
+        cluster_cpus = cluster["cpus"]
         cpu_metric_dict[name+"_active"] = int(
             100
-            * sum(map(lambda x: 1.0 - x["idle_ratio"], cluster["cpus"]))
-            / len(cluster["cpus"])
+            * sum(map(lambda x: 1.0 - x["idle_ratio"], cluster_cpus))
+            / len(cluster_cpus)
         )
-        for cpu in cluster["cpus"]:
+        for cpu in cluster_cpus:
             name = 'E-Cluster' if name[0] == 'E' else 'P-Cluster'
             core = e_core if name[0] == 'E' else p_core
             core.append(cpu["cpu"])

--- a/asitop/parsers.py
+++ b/asitop/parsers.py
@@ -85,7 +85,11 @@ def parse_cpu_metrics(powermetrics_parse):
     for cluster in cpu_clusters:
         name = cluster["name"]
         cpu_metric_dict[name+"_freq_Mhz"] = int(cluster["freq_hz"]/(1e6))
-        cpu_metric_dict[name+"_active"] = int((1 - cluster["idle_ratio"])*100)
+        cpu_metric_dict[name+"_active"] = int(
+            100
+            * sum(map(lambda x: 1.0 - x["idle_ratio"], cluster["cpus"]))
+            / len(cluster["cpus"])
+        )
         for cpu in cluster["cpus"]:
             name = 'E-Cluster' if name[0] == 'E' else 'P-Cluster'
             core = e_core if name[0] == 'E' else p_core


### PR DESCRIPTION
Fixes #59 

I'm not sure this is equivalent to the previous value, but it works as expected with and without load on the CPU.

Verified to work on M3 macbook.