### PR TITLE
Don't allow the 'show_cores' option to take any arguments.

### DIFF
--- a/asitop/asitop.py
+++ b/asitop/asitop.py
@@ -12,7 +12,7 @@ parser.add_argument('--color', type=int, default=2,
                     help='Choose display color (0~8)')
 parser.add_argument('--avg', type=int, default=30,
                     help='Interval for averaged values (seconds)')
-parser.add_argument('--show_cores', type=bool, default=False,
+parser.add_argument('--show_cores', type=bool, default=False, action='store_true',
                     help='Choose show cores mode')
 parser.add_argument('--max_count', type=int, default=0,
                     help='Max show count to restart powermetrics')


### PR DESCRIPTION
The type of 'show_cores' in the parser is bool. So the usages below look awkward.

asitop --show_cores 0
asitop --show_cores 1
...

Instead, it should be, asitop --show_cores