### PR TITLE
fix: memory leak in parse_powermetrics — stop reading entire file every tick

### DIFF
--- a/asitop/utils.py
+++ b/asitop/utils.py
@@ -5,7 +5,6 @@ from subprocess import PIPE
 import psutil
 from .parsers import (
     parse_thermal_pressure,
-    parse_bandwidth_metrics,
     parse_cpu_metrics,
     parse_gpu_metrics,
 )

--- a/asitop/utils.py
+++ b/asitop/utils.py
@@ -8,31 +8,73 @@ import plistlib
 
 
 def parse_powermetrics(path='/tmp/asitop_powermetrics', timecode="0"):
-    data = None
+    """Parse the most recent plist entry from the powermetrics output file.
+
+    powermetrics appends plist entries separated by null bytes (\\x00) to a
+    continuously growing file. The previous implementation read the *entire*
+    file on every call (once per second by default), then split all contents
+    into memory. After multi-day runs the file grows into gigabytes, causing
+    asitop to consume 6 GB+ RSS (observed on an M4 Mac mini after ~3 days).
+
+    This implementation seeks to the end of the file and reads *backwards* in
+    64 KB chunks until it has found at least two null-byte-separated segments.
+    Only those final segments are loaded into memory, so memory usage stays
+    constant regardless of how long asitop has been running.
+    """
+    CHUNK_SIZE = 65536  # 64 KB — larger than any single powermetrics plist entry
+
     try:
-        with open(path+timecode, 'rb') as fp:
-            data = fp.read()
-        data = data.split(b'\x00')
-        powermetrics_parse = plistlib.loads(data[-1])
-        thermal_pressure = parse_thermal_pressure(powermetrics_parse)
-        cpu_metrics_dict = parse_cpu_metrics(powermetrics_parse)
-        gpu_metrics_dict = parse_gpu_metrics(powermetrics_parse)
-        #bandwidth_metrics = parse_bandwidth_metrics(powermetrics_parse)
-        bandwidth_metrics = None
-        timestamp = powermetrics_parse["timestamp"]
-        return cpu_metrics_dict, gpu_metrics_dict, thermal_pressure, bandwidth_metrics, timestamp
-    except Exception as e:
-        if data:
-            if len(data) > 1:
-                powermetrics_parse = plistlib.loads(data[-2])
-                thermal_pressure = parse_thermal_pressure(powermetrics_parse)
-                cpu_metrics_dict = parse_cpu_metrics(powermetrics_parse)
-                gpu_metrics_dict = parse_gpu_metrics(powermetrics_parse)
-                #bandwidth_metrics = parse_bandwidth_metrics(powermetrics_parse)
-                bandwidth_metrics = None
-                timestamp = powermetrics_parse["timestamp"]
-                return cpu_metrics_dict, gpu_metrics_dict, thermal_pressure, bandwidth_metrics, timestamp
+        with open(path + timecode, 'rb') as fp:
+            fp.seek(0, 2)
+            file_size = fp.tell()
+
+            if file_size == 0:
+                return False
+
+            # Read backwards in chunks until we have ≥2 null-byte separators.
+            # With ≥2 separators we get ≥3 segments, guaranteeing both a
+            # primary candidate (segments[-1]) and a fallback (segments[-2]).
+            tail = b''
+            pos = file_size
+
+            while pos > 0:
+                read_size = min(CHUNK_SIZE, pos)
+                pos -= read_size
+                fp.seek(pos)
+                tail = fp.read(read_size) + tail
+                if tail.count(b'\x00') >= 2:
+                    break
+
+        segments = tail.split(b'\x00')
+
+    except Exception:
         return False
+
+    def _parse_segment(segment):
+        """Parse a single plist segment, returning the metrics tuple or None."""
+        segment = segment.strip(b'\x00')
+        if not segment:
+            return None
+        try:
+            powermetrics_parse = plistlib.loads(segment)
+            thermal_pressure = parse_thermal_pressure(powermetrics_parse)
+            cpu_metrics_dict = parse_cpu_metrics(powermetrics_parse)
+            gpu_metrics_dict = parse_gpu_metrics(powermetrics_parse)
+            # bandwidth_metrics = parse_bandwidth_metrics(powermetrics_parse)
+            bandwidth_metrics = None
+            timestamp = powermetrics_parse["timestamp"]
+            return cpu_metrics_dict, gpu_metrics_dict, thermal_pressure, bandwidth_metrics, timestamp
+        except Exception:
+            return None
+
+    # Try segments from most-recent to oldest; the very last segment may be
+    # a partial write in progress, so fall back to earlier complete entries.
+    for segment in reversed(segments):
+        result = _parse_segment(segment)
+        if result is not None:
+            return result
+
+    return False
 
 
 def clear_console():

--- a/asitop/utils.py
+++ b/asitop/utils.py
@@ -3,7 +3,12 @@ import glob
 import subprocess
 from subprocess import PIPE
 import psutil
-from .parsers import *
+from .parsers import (
+    parse_thermal_pressure,
+    parse_bandwidth_metrics,
+    parse_cpu_metrics,
+    parse_gpu_metrics,
+)
 import plistlib
 
 


### PR DESCRIPTION
## Bug

`parse_powermetrics()` in `asitop/utils.py` is called once per second (by default). Each call does:

```python
data = fp.read()              # reads entire file into memory
data = data.split(b'\x00')   # splits all contents
powermetrics_parse = plistlib.loads(data[-1])  # only last entry used
```

`powermetrics` continuously appends plist samples separated by null bytes (`\x00`) to `/tmp/asitop_powermetrics{timecode}`. **The file is never truncated.** After days of running it grows into the gigabyte range, and reading + splitting gigabytes every second causes RSS to balloon accordingly.

**Observed:** 6 GB+ RSS on an M4 Mac mini after ~3 days of continuous use.

## Fix

Seek to the **end** of the file and read **backwards** in 64 KB chunks until at least two null-byte separators are found. Only those final segments are ever loaded into memory:

```python
while pos > 0:
    read_size = min(CHUNK_SIZE, pos)
    pos -= read_size
    fp.seek(pos)
    tail = fp.read(read_size) + tail
    if tail.count(b'\x00') >= 2:
        break

segments = tail.split(b'\x00')
```

A 64 KB chunk is larger than any single powermetrics plist entry, so in practice this requires only **one or two iterations** (≈64–128 KB read) regardless of how large the file has grown.

The fallback to the second-to-last entry (needed when powermetrics is mid-write on the final entry) is preserved: we iterate segments from most-recent to oldest and return the first one that parses successfully.

## What was not changed

- **`HChart.datapoints`** in dashing already uses `deque(maxlen=500)` — chart lists are already bounded.
- The powermetrics temp file itself continues to grow on disk. Truncating it safely while powermetrics holds it open is complex and error-prone; the file lives in `/tmp` and is cleaned on reboot, so this is acceptable.

## Testing

Verified the reverse-read logic with synthetic test files (small files, and 500-entry ~500 KB files) confirming correct segment extraction and that only a bounded buffer is loaded per call.